### PR TITLE
Bugfix/cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,8 @@ install(TARGETS
   imu_node
   DESTINATION lib/${PROJECT_NAME})
 
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME})
+
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ install(TARGETS
 
 install(DIRECTORY
   launch
+  rviz2
   DESTINATION share/${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
下記のissueに対する修正です。
https://github.com/KBKN-Autonomous-Robotics-Lab/orange_ros2/issues/47

`install()`コマンドをCMakeLists.txtに追加することでlaunchrviz2フォルダを`share/${PROJECT_NAME}`ディレクトリにインストールします。